### PR TITLE
legacy-um: allow hostapd to use /data/vendor/wifi/hostapd

### DIFF
--- a/legacy/vendor/common/hal_wifi_hostapd.te
+++ b/legacy/vendor/common/hal_wifi_hostapd.te
@@ -44,3 +44,4 @@ allow hal_wifi_hostapd_default wigighalsvc:unix_dgram_socket sendto;
 # allow hostapd to attach to fstman socket
 allow hal_wifi_hostapd_default wifi_vendor_wpa_socket:dir r_dir_perms;
 allow hal_wifi_hostapd_default wifi_vendor_wpa_socket:sock_file rw_file_perms;
+allow hal_wifi_hostapd_default wifi_vendor_data_file:dir create_dir_perms;


### PR DESCRIPTION
some interfaces need to be created at /data/vendor/wifi/hostapd and
hostapd controls that so giving create_dir_perms to wifi_vendor_data_file.

Signed-off-by: Jyotiraditya <jyotiraditya@aospa.co>
Change-Id: I37a8e487923c956eca1fed70514b74c0b735bd56